### PR TITLE
fix: link mcpi to mcpi-ext repo

### DIFF
--- a/_blog/progressive-discovery-in-mcp-part-1.md
+++ b/_blog/progressive-discovery-in-mcp-part-1.md
@@ -36,7 +36,7 @@ I got bored waiting for others, so I finally built the thing I kept talking abou
 
 ## Three tiers, three characters
 
-[mcpi](https://github.com/SamMorrowDrums/mcpi) is an experimental fork of [pi](https://pi.dev/) + [extension](https://github.com/SamMorrowDrums/mcpi-ext) that implements three complementary strategies for progressive tool discovery. Each pays only the context tokens it needs. Each handles a different shape of work. And because the best ideas deserve characters, each has a name.
+[mcpi](https://github.com/SamMorrowDrums/mcpi-ext) is an experimental fork of [pi](https://pi.dev/) + [extension](https://github.com/SamMorrowDrums/mcpi-ext) that implements three complementary strategies for progressive tool discovery. Each pays only the context tokens it needs. Each handles a different shape of work. And because the best ideas deserve characters, each has a name.
 
 | Tier | Name | Mechanism | Best for |
 | --- | --- | --- | --- |


### PR DESCRIPTION
Link mcpi to the mcpi-ext repo which has the instructions and links.