### PR TITLE
chore: push part 5 publish date to 2026-06-17

### DIFF
--- a/_blog/progressive-discovery-in-mcp-part-5.md
+++ b/_blog/progressive-discovery-in-mcp-part-5.md
@@ -1,6 +1,6 @@
 ---
 title: "Three Is Not Redundancy"
-date: '2026-06-10T00:00:00.000Z'
+date: '2026-06-17T00:00:00.000Z'
 slug: 'progressive-discovery-in-mcp-part-5'
 ---
 

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -5,7 +5,7 @@
     <link>https://sam-morrow.com</link>
     <description>Drummer, software engineer and online-learning fanatic.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 03 Jun 2026 21:32:23 GMT</lastBuildDate>
+    <lastBuildDate>Wed, 10 Jun 2026 10:50:54 GMT</lastBuildDate>
     <atom:link href="https://sam-morrow.com/rss.xml" rel="self" type="application/rss+xml"/>
     <item>
       <title>Code Mode</title>


### PR DESCRIPTION
Pushes the publish date of *Progressive Discovery in MCP — Part 5* out by a week. Not ready to publish yet; future-dated posts are filtered out by `getAllBlogPosts()`.

RSS regenerated to drop the post.