### PR TITLE
chore: unpublish Progressive Discovery part 5

### DIFF
--- a/_blog/progressive-discovery-in-mcp-part-5.md
+++ b/_blog/progressive-discovery-in-mcp-part-5.md
@@ -1,6 +1,6 @@
 ---
 title: "Three Is Not Redundancy"
-date: '2026-06-17T00:00:00.000Z'
+date: '2026-07-13T00:00:00.000Z'
 slug: 'progressive-discovery-in-mcp-part-5'
 ---
 


### PR DESCRIPTION
Part 5 ("Three Is Not Redundancy") isn't drafted/ready yet, but its publish date (`2026-06-17`) is now in the past, so the date-gated blog filter (`lib/api.mjs`) was showing it live.

This pushes the publish date out ~3 weeks to `2026-07-13`, which hides the post from the blog index, individual page rendering, and the RSS feed (all gated on `date <= today`) until it's finished. RSS regenerates on build, so the committed feed (which already excludes part 5) stays correct.

No content changes — date only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>